### PR TITLE
Document our "About" and "Server rules"

### DIFF
--- a/thoughtbot-about.md
+++ b/thoughtbot-about.md
@@ -20,7 +20,9 @@ Existing employees are also subject to this anti-harassment policy. Violation wi
 
 If anyone engages in harassing behavior, including maintainers, we will take appropriate action, up to and including warning the offender, escalation to their admin, and defederation.
 
-If you are being harassed, notice that someone else is being harassed, or have any other concerns, please report them immediately.
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please report them immediately in your Mastodon app. You can do this by clicking `…` on the post, then "Report". All of these reports go to us; you may also choose to send an anonymous report to the other instance's moderation team.
+
+If you report a teammate to us, we will handle it with discretion as [documented in our Handbook](https://hub.thoughtbot.com/handbook/policies/conduct.md#reporting-and-discipline) (internal link).
 
 We expect everyone to follow these rules anywhere in thoughtbot’s project codebases, issue trackers, chatrooms, mailing lists, and social network.
 

--- a/thoughtbot-about.md
+++ b/thoughtbot-about.md
@@ -1,0 +1,35 @@
+# thoughtbot.social
+
+## Code of Conduct
+
+In order to foster an inclusive, kind, harassment-free, and cooperative community, thoughtbot enforces this code of conduct on this social network.
+
+### Summary
+
+Harassment in code and discussion or violation of physical boundaries is completely unacceptable anywhere in thoughtbot’s social network, project codebases, issue trackers, chatrooms, mailing lists, meetups, and other events. The core team uses their discresion to choose whether to warn violators. Repeat violations will result in being blocked or banned by the core team at or before the 3rd violation.
+
+Existing employees are expected to live up to the same standards and will be handled by our internal processes.
+
+### In detail
+
+Harassment includes offensive verbal comments related to gender identity, gender expression, sexual orientation, disability, physical appearance, body size, race, religion, sexual images, deliberate intimidation, stalking, sustained disruption, and unwelcome sexual attention.
+
+Individuals asked to stop any harassing behavior are expected to comply immediately.
+
+Existing employees are also subject to the anti-harassment policy. Violation will be handled internally in our usual manner.
+
+If anyone engages in harassing behavior, including maintainers, we may take appropriate action, up to and including warning the offender, escalation to their admin, and defederation.
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please report them immediately.
+
+We expect everyone to follow these rules anywhere in thoughtbot’s project codebases, issue trackers, chatrooms, mailing lists, and social network.
+
+Finally, don’t forget that it is human to make mistakes! We all do. Let’s work together to help each other, resolve issues, and learn from the mistakes that we will all inevitably make from time to time.
+
+### Thanks
+
+Thanks to the CocoaPods Code of Conduct, Bundler Code of Conduct, JSConf Code of Conduct, and Contributor Covenant for inspiration and ideas.
+
+### License
+
+To the extent possible under law, the thoughtbot team has waived all copyright and related or neighboring rights to thoughtbot Code of Conduct. This work is published from the United States.

--- a/thoughtbot-about.md
+++ b/thoughtbot-about.md
@@ -16,7 +16,7 @@ Harassment includes offensive verbal comments related to gender identity, gender
 
 Individuals asked to stop any harassing behavior are expected to comply immediately.
 
-Existing employees are also subject to the anti-harassment policy. Violation will be handled internally in our usual manner.
+Existing employees are also subject to this anti-harassment policy. Violation will be handled internally in our usual manner.
 
 If anyone engages in harassing behavior, including maintainers, we will take appropriate action, up to and including warning the offender, escalation to their admin, and defederation.
 

--- a/thoughtbot-about.md
+++ b/thoughtbot-about.md
@@ -18,7 +18,7 @@ Individuals asked to stop any harassing behavior are expected to comply immediat
 
 Existing employees are also subject to the anti-harassment policy. Violation will be handled internally in our usual manner.
 
-If anyone engages in harassing behavior, including maintainers, we may take appropriate action, up to and including warning the offender, escalation to their admin, and defederation.
+If anyone engages in harassing behavior, including maintainers, we will take appropriate action, up to and including warning the offender, escalation to their admin, and defederation.
 
 If you are being harassed, notice that someone else is being harassed, or have any other concerns, please report them immediately.
 

--- a/thoughtbot-server-rules.md
+++ b/thoughtbot-server-rules.md
@@ -1,0 +1,4 @@
+- This is a company instance so keep it safe for work.
+- No attacking gender, orientation, disability, physical appearance, body size, race, or religion.
+- No sexual images, deliberate intimidation, stalking, or unwelcome sexual attention.
+- Report these acts and we will take care of them.


### PR DESCRIPTION
The Mastodon software provides a public interface for an instance's description and summary of their rules. It is customary to use this space to demonstrate our commitment to moderate our instance, both to our users and to those who interact with them.

This commit introduces these rules as Markdown files into the Mastodon repo. This is not the final step -- the agreed-upon text must then be pasted into a textarea. This is simply a place for us to discuss and archive the text, in a format and UX that is familiar.